### PR TITLE
Send messages as string

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -169,9 +169,6 @@ class RPCClient extends EventEmitter {
     sendRaw(buffer) {
         if ([OPEN, CLOSING].includes(this._state) && this._ws) {
             // can send while closing so long as websocket doesn't mind
-            if (!Buffer.isBuffer(buffer)) {
-                buffer = Buffer.from(buffer, 'utf8');
-            }
             this._ws.send(buffer);
             this.emit('message', {buffer, outbound: true});
         } else if (this._state === CONNECTING) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "nyc": "^15.1.0"
       },
       "engines": {
-        "node": ">=15.9.0"
+        "node": ">=17.2.0"
       }
     },
     "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
Hello
is there any reason to send the messages as buffer?
because my charger doesn't understand buffer responses and work fine when messages are sent as string
