### PR TITLE
Update ajv to 8.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -796,7 +796,7 @@ This module natively supports the following validation schemas:
 
 If you want to use `strictMode` with a subprotocol which is not included in the list above, you will need to add the appropriate schemas yourself. To do this, you must create a `Validator` for each subprotocol and pass them to the RPC constructor using the `strictModeValidators` option.  (It is also possible to override the built-in validators this way.)
 
-To create a Validator, you should pass the name of the subprotocol and a well-formed json schema to [`createValidator()`](#createvalidatorsubprotocol-schema). An example of a well-formed schema can be found at [`./lib/schemas/ocpp1_6.json`](./lib/schemas/ocpp1_6.json) or [`./lib/schemas/ocpp2_0_1.json`](./lib/schemas/ocpp2_0_1.json) or in the example below.
+To create a Validator, you should pass the name of the subprotocol and a well-formed json schema to [`createValidator()`](#createvalidatorsubprotocol-schema). An example of a well-formed schema can be found at [`./lib/schemas/ocpp1_6.json`](./lib/schemas/ocpp1_6.json) or [`./lib/schemas/ocpp2_0_1.json`](./lib/schemas/ocpp2_0_1.json) or in the example below. The library expects namespace identifier of the `urn` to be equal the passed subprotocol.
 
 Example:
 
@@ -805,7 +805,7 @@ Example:
 const echoValidator = createValidator('echo1.0', [
     {
         $schema: "http://json-schema.org/draft-07/schema",
-        $id: "urn:Echo.req",
+        $id: "urn:echo1.0:Echo.req",
         type: "object",
         properties: {
             val: { type: "string" }
@@ -815,7 +815,7 @@ const echoValidator = createValidator('echo1.0', [
     },
     {
         $schema: "http://json-schema.org/draft-07/schema",
-        $id: "urn:Echo.conf",
+        $id: "urn:echo1.0:Echo.conf",
         type: "object",
         properties: {
             val: { type: "string" }

--- a/lib/client.js
+++ b/lib/client.js
@@ -307,7 +307,7 @@ class RPCClient extends EventEmitter {
             // perform some strict-mode checks
             const validator = this._strictValidators.get(this._protocol);
             try {
-                validator.validate(`urn:${method}.req`, params);
+                validator.validate(`urn:${this._protocol}:${method}.req`, params);
             } catch (error) {
                 this.emit('strictValidationFailure', {
                     messageId: msgId,
@@ -819,7 +819,7 @@ class RPCClient extends EventEmitter {
                     // perform some strict-mode checks
                     const validator = this._strictValidators.get(this._protocol);
                     try {
-                        validator.validate(`urn:${method}.req`, params);
+                        validator.validate(`urn:${this._protocol}:${method}.req`, params);
                     } catch (error) {
                         this.emit('strictValidationFailure', {
                             messageId: msgId,
@@ -879,7 +879,7 @@ class RPCClient extends EventEmitter {
                     // perform some strict-mode checks
                     const validator = this._strictValidators.get(this._protocol);
                     try {
-                        validator.validate(`urn:${method}.conf`, result);
+                        validator.validate(`urn:${this._protocol}:${method}.conf`, result);
                     } catch (error) {
                         this.emit('strictValidationFailure', {
                             messageId: msgId,
@@ -951,7 +951,7 @@ class RPCClient extends EventEmitter {
                 // perform some strict-mode checks
                 const validator = this._strictValidators.get(this._protocol);
                 try {
-                    validator.validate(`urn:${pendingCall.method}.conf`, result);
+                    validator.validate(`urn:${this._protocol}:${pendingCall.method}.conf`, result);
                 } catch (error) {
                     this.emit('strictValidationFailure', {
                         messageId: msgId,

--- a/lib/schemas/ocpp1_6.json
+++ b/lib/schemas/ocpp1_6.json
@@ -1,6 +1,6 @@
 [
     {
-        "$id": "urn:Authorize.req",
+        "$id": "urn:ocpp1.6:Authorize.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -15,7 +15,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:Authorize.conf",
+        "$id": "urn:ocpp1.6:Authorize.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -53,7 +53,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:BootNotification.req",
+        "$id": "urn:ocpp1.6:BootNotification.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -101,7 +101,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:BootNotification.conf",
+        "$id": "urn:ocpp1.6:BootNotification.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -129,7 +129,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:CancelReservation.req",
+        "$id": "urn:ocpp1.6:CancelReservation.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -143,7 +143,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:CancelReservation.conf",
+        "$id": "urn:ocpp1.6:CancelReservation.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -161,7 +161,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:CertificateSigned.req",
+        "$id": "urn:ocpp1.6:CertificateSigned.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -176,7 +176,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:CertificateSigned.conf",
+        "$id": "urn:ocpp1.6:CertificateSigned.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -199,7 +199,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ChangeAvailability.req",
+        "$id": "urn:ocpp1.6:ChangeAvailability.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -221,7 +221,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ChangeAvailability.conf",
+        "$id": "urn:ocpp1.6:ChangeAvailability.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -240,7 +240,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ChangeConfiguration.req",
+        "$id": "urn:ocpp1.6:ChangeConfiguration.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -260,7 +260,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ChangeConfiguration.conf",
+        "$id": "urn:ocpp1.6:ChangeConfiguration.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -280,14 +280,14 @@
         "type": "object"
     },
     {
-        "$id": "urn:ClearCache.req",
+        "$id": "urn:ocpp1.6:ClearCache.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {},
         "type": "object"
     },
     {
-        "$id": "urn:ClearCache.conf",
+        "$id": "urn:ocpp1.6:ClearCache.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -305,7 +305,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ClearChargingProfile.req",
+        "$id": "urn:ocpp1.6:ClearChargingProfile.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -330,7 +330,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ClearChargingProfile.conf",
+        "$id": "urn:ocpp1.6:ClearChargingProfile.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -348,7 +348,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:DataTransfer.req",
+        "$id": "urn:ocpp1.6:DataTransfer.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -370,7 +370,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:DataTransfer.conf",
+        "$id": "urn:ocpp1.6:DataTransfer.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -393,7 +393,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:DeleteCertificate.req",
+        "$id": "urn:ocpp1.6:DeleteCertificate.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -444,7 +444,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:DeleteCertificate.conf",
+        "$id": "urn:ocpp1.6:DeleteCertificate.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -468,7 +468,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:DiagnosticsStatusNotification.req",
+        "$id": "urn:ocpp1.6:DiagnosticsStatusNotification.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -488,14 +488,14 @@
         "type": "object"
     },
     {
-        "$id": "urn:DiagnosticsStatusNotification.conf",
+        "$id": "urn:ocpp1.6:DiagnosticsStatusNotification.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {},
         "type": "object"
     },
     {
-        "$id": "urn:ExtendedTriggerMessage.req",
+        "$id": "urn:ocpp1.6:ExtendedTriggerMessage.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -526,7 +526,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ExtendedTriggerMessage.conf",
+        "$id": "urn:ocpp1.6:ExtendedTriggerMessage.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -550,7 +550,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:FirmwareStatusNotification.req",
+        "$id": "urn:ocpp1.6:FirmwareStatusNotification.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -573,14 +573,14 @@
         "type": "object"
     },
     {
-        "$id": "urn:FirmwareStatusNotification.conf",
+        "$id": "urn:ocpp1.6:FirmwareStatusNotification.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {},
         "type": "object"
     },
     {
-        "$id": "urn:GetCompositeSchedule.req",
+        "$id": "urn:ocpp1.6:GetCompositeSchedule.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -605,7 +605,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetCompositeSchedule.conf",
+        "$id": "urn:ocpp1.6:GetCompositeSchedule.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -681,7 +681,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetConfiguration.req",
+        "$id": "urn:ocpp1.6:GetConfiguration.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -696,7 +696,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetConfiguration.conf",
+        "$id": "urn:ocpp1.6:GetConfiguration.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -735,7 +735,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetDiagnostics.req",
+        "$id": "urn:ocpp1.6:GetDiagnostics.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -764,7 +764,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetDiagnostics.conf",
+        "$id": "urn:ocpp1.6:GetDiagnostics.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -776,7 +776,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetInstalledCertificateIds.req",
+        "$id": "urn:ocpp1.6:GetInstalledCertificateIds.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -799,7 +799,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetInstalledCertificateIds.conf",
+        "$id": "urn:ocpp1.6:GetInstalledCertificateIds.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -864,14 +864,14 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetLocalListVersion.req",
+        "$id": "urn:ocpp1.6:GetLocalListVersion.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {},
         "type": "object"
     },
     {
-        "$id": "urn:GetLocalListVersion.conf",
+        "$id": "urn:ocpp1.6:GetLocalListVersion.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -885,7 +885,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetLog.req",
+        "$id": "urn:ocpp1.6:GetLog.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -943,7 +943,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetLog.conf",
+        "$id": "urn:ocpp1.6:GetLog.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -971,14 +971,14 @@
         "type": "object"
     },
     {
-        "$id": "urn:Heartbeat.req",
+        "$id": "urn:ocpp1.6:Heartbeat.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {},
         "type": "object"
     },
     {
-        "$id": "urn:Heartbeat.conf",
+        "$id": "urn:ocpp1.6:Heartbeat.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -993,7 +993,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:InstallCertificate.req",
+        "$id": "urn:ocpp1.6:InstallCertificate.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1021,7 +1021,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:InstallCertificate.conf",
+        "$id": "urn:ocpp1.6:InstallCertificate.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1045,7 +1045,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:LogStatusNotification.req",
+        "$id": "urn:ocpp1.6:LogStatusNotification.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1076,13 +1076,13 @@
         "type": "object"
     },
     {
-        "$id": "urn:LogStatusNotification.conf",
+        "$id": "urn:ocpp1.6:LogStatusNotification.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "type": "object"
     },
     {
-        "$id": "urn:MeterValues.req",
+        "$id": "urn:ocpp1.6:MeterValues.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -1226,14 +1226,14 @@
         "type": "object"
     },
     {
-        "$id": "urn:MeterValues.conf",
+        "$id": "urn:ocpp1.6:MeterValues.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {},
         "type": "object"
     },
     {
-        "$id": "urn:RemoteStartTransaction.req",
+        "$id": "urn:ocpp1.6:RemoteStartTransaction.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -1355,7 +1355,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:RemoteStartTransaction.conf",
+        "$id": "urn:ocpp1.6:RemoteStartTransaction.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -1373,7 +1373,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:RemoteStopTransaction.req",
+        "$id": "urn:ocpp1.6:RemoteStopTransaction.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -1387,7 +1387,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:RemoteStopTransaction.conf",
+        "$id": "urn:ocpp1.6:RemoteStopTransaction.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -1405,7 +1405,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ReserveNow.req",
+        "$id": "urn:ocpp1.6:ReserveNow.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -1437,7 +1437,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ReserveNow.conf",
+        "$id": "urn:ocpp1.6:ReserveNow.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -1458,7 +1458,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:Reset.req",
+        "$id": "urn:ocpp1.6:Reset.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -1476,7 +1476,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:Reset.conf",
+        "$id": "urn:ocpp1.6:Reset.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -1494,7 +1494,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SecurityEventNotification.req",
+        "$id": "urn:ocpp1.6:SecurityEventNotification.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -1518,13 +1518,13 @@
         "type": "object"
     },
     {
-        "$id": "urn:SecurityEventNotification.conf",
+        "$id": "urn:ocpp1.6:SecurityEventNotification.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "type": "object"
     },
     {
-        "$id": "urn:SendLocalList.req",
+        "$id": "urn:ocpp1.6:SendLocalList.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -1589,7 +1589,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SendLocalList.conf",
+        "$id": "urn:ocpp1.6:SendLocalList.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -1609,7 +1609,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SetChargingProfile.req",
+        "$id": "urn:ocpp1.6:SetChargingProfile.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -1728,7 +1728,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SetChargingProfile.conf",
+        "$id": "urn:ocpp1.6:SetChargingProfile.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -1747,7 +1747,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SignCertificate.req",
+        "$id": "urn:ocpp1.6:SignCertificate.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -1762,7 +1762,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SignCertificate.conf",
+        "$id": "urn:ocpp1.6:SignCertificate.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1785,7 +1785,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SignedFirmwareStatusNotification.req",
+        "$id": "urn:ocpp1.6:SignedFirmwareStatusNotification.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1823,13 +1823,13 @@
         "type": "object"
     },
     {
-        "$id": "urn:SignedFirmwareStatusNotification.conf",
+        "$id": "urn:ocpp1.6:SignedFirmwareStatusNotification.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "type": "object"
     },
     {
-        "$id": "urn:SignedUpdateFirmware.req",
+        "$id": "urn:ocpp1.6:SignedUpdateFirmware.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1887,7 +1887,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SignedUpdateFirmware.conf",
+        "$id": "urn:ocpp1.6:SignedUpdateFirmware.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1913,7 +1913,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:StartTransaction.req",
+        "$id": "urn:ocpp1.6:StartTransaction.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -1944,7 +1944,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:StartTransaction.conf",
+        "$id": "urn:ocpp1.6:StartTransaction.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -1986,7 +1986,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:StatusNotification.req",
+        "$id": "urn:ocpp1.6:StatusNotification.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -2053,14 +2053,14 @@
         "type": "object"
     },
     {
-        "$id": "urn:StatusNotification.conf",
+        "$id": "urn:ocpp1.6:StatusNotification.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {},
         "type": "object"
     },
     {
-        "$id": "urn:StopTransaction.req",
+        "$id": "urn:ocpp1.6:StopTransaction.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -2229,7 +2229,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:StopTransaction.conf",
+        "$id": "urn:ocpp1.6:StopTransaction.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -2264,7 +2264,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:TriggerMessage.req",
+        "$id": "urn:ocpp1.6:TriggerMessage.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -2289,7 +2289,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:TriggerMessage.conf",
+        "$id": "urn:ocpp1.6:TriggerMessage.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -2308,7 +2308,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:UnlockConnector.req",
+        "$id": "urn:ocpp1.6:UnlockConnector.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -2322,7 +2322,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:UnlockConnector.conf",
+        "$id": "urn:ocpp1.6:UnlockConnector.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -2341,7 +2341,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:UpdateFirmware.req",
+        "$id": "urn:ocpp1.6:UpdateFirmware.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {
@@ -2367,7 +2367,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:UpdateFirmware.conf",
+        "$id": "urn:ocpp1.6:UpdateFirmware.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "properties": {},

--- a/lib/schemas/ocpp2_0_1.json
+++ b/lib/schemas/ocpp2_0_1.json
@@ -1,6 +1,6 @@
 [
     {
-        "$id": "urn:Authorize.req",
+        "$id": "urn:ocpp2.0.1:Authorize.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -162,7 +162,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:Authorize.conf",
+        "$id": "urn:ocpp2.0.1:Authorize.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -381,7 +381,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:BootNotification.req",
+        "$id": "urn:ocpp2.0.1:BootNotification.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -489,7 +489,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:BootNotification.conf",
+        "$id": "urn:ocpp2.0.1:BootNotification.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -567,7 +567,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:CancelReservation.req",
+        "$id": "urn:ocpp2.0.1:CancelReservation.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -600,7 +600,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:CancelReservation.conf",
+        "$id": "urn:ocpp2.0.1:CancelReservation.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -666,7 +666,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:CertificateSigned.req",
+        "$id": "urn:ocpp2.0.1:CertificateSigned.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -711,7 +711,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:CertificateSigned.conf",
+        "$id": "urn:ocpp2.0.1:CertificateSigned.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -777,7 +777,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ChangeAvailability.req",
+        "$id": "urn:ocpp2.0.1:ChangeAvailability.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -841,7 +841,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ChangeAvailability.conf",
+        "$id": "urn:ocpp2.0.1:ChangeAvailability.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -908,7 +908,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ClearCache.req",
+        "$id": "urn:ocpp2.0.1:ClearCache.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -934,7 +934,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ClearCache.conf",
+        "$id": "urn:ocpp2.0.1:ClearCache.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1000,7 +1000,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ClearChargingProfile.req",
+        "$id": "urn:ocpp2.0.1:ClearChargingProfile.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1064,7 +1064,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ClearChargingProfile.conf",
+        "$id": "urn:ocpp2.0.1:ClearChargingProfile.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1130,7 +1130,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ClearDisplayMessage.req",
+        "$id": "urn:ocpp2.0.1:ClearDisplayMessage.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1163,7 +1163,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ClearDisplayMessage.conf",
+        "$id": "urn:ocpp2.0.1:ClearDisplayMessage.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1229,7 +1229,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ClearedChargingLimit.req",
+        "$id": "urn:ocpp2.0.1:ClearedChargingLimit.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1275,7 +1275,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ClearedChargingLimit.conf",
+        "$id": "urn:ocpp2.0.1:ClearedChargingLimit.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1301,7 +1301,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ClearVariableMonitoring.req",
+        "$id": "urn:ocpp2.0.1:ClearVariableMonitoring.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1339,7 +1339,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ClearVariableMonitoring.conf",
+        "$id": "urn:ocpp2.0.1:ClearVariableMonitoring.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1431,7 +1431,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:CostUpdated.req",
+        "$id": "urn:ocpp2.0.1:CostUpdated.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1470,7 +1470,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:CostUpdated.conf",
+        "$id": "urn:ocpp2.0.1:CostUpdated.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1496,7 +1496,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:CustomerInformation.req",
+        "$id": "urn:ocpp2.0.1:CustomerInformation.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1660,7 +1660,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:CustomerInformation.conf",
+        "$id": "urn:ocpp2.0.1:CustomerInformation.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1727,7 +1727,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:DataTransfer.req",
+        "$id": "urn:ocpp2.0.1:DataTransfer.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1769,7 +1769,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:DataTransfer.conf",
+        "$id": "urn:ocpp2.0.1:DataTransfer.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1840,7 +1840,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:DeleteCertificate.req",
+        "$id": "urn:ocpp2.0.1:DeleteCertificate.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1914,7 +1914,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:DeleteCertificate.conf",
+        "$id": "urn:ocpp2.0.1:DeleteCertificate.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -1981,7 +1981,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:FirmwareStatusNotification.req",
+        "$id": "urn:ocpp2.0.1:FirmwareStatusNotification.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -2037,7 +2037,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:FirmwareStatusNotification.conf",
+        "$id": "urn:ocpp2.0.1:FirmwareStatusNotification.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -2063,7 +2063,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:Get15118EVCertificate.req",
+        "$id": "urn:ocpp2.0.1:Get15118EVCertificate.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -2115,7 +2115,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:Get15118EVCertificate.conf",
+        "$id": "urn:ocpp2.0.1:Get15118EVCertificate.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -2187,7 +2187,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetBaseReport.req",
+        "$id": "urn:ocpp2.0.1:GetBaseReport.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -2233,7 +2233,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetBaseReport.conf",
+        "$id": "urn:ocpp2.0.1:GetBaseReport.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -2301,7 +2301,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetCertificateStatus.req",
+        "$id": "urn:ocpp2.0.1:GetCertificateStatus.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -2381,7 +2381,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetCertificateStatus.conf",
+        "$id": "urn:ocpp2.0.1:GetCertificateStatus.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -2452,7 +2452,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetChargingProfiles.req",
+        "$id": "urn:ocpp2.0.1:GetChargingProfiles.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -2548,7 +2548,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetChargingProfiles.conf",
+        "$id": "urn:ocpp2.0.1:GetChargingProfiles.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -2614,7 +2614,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetCompositeSchedule.req",
+        "$id": "urn:ocpp2.0.1:GetCompositeSchedule.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -2663,7 +2663,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetCompositeSchedule.conf",
+        "$id": "urn:ocpp2.0.1:GetCompositeSchedule.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -2811,7 +2811,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetDisplayMessages.req",
+        "$id": "urn:ocpp2.0.1:GetDisplayMessages.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -2878,7 +2878,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetDisplayMessages.conf",
+        "$id": "urn:ocpp2.0.1:GetDisplayMessages.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -2944,7 +2944,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetInstalledCertificateIds.req",
+        "$id": "urn:ocpp2.0.1:GetInstalledCertificateIds.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -2989,7 +2989,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetInstalledCertificateIds.conf",
+        "$id": "urn:ocpp2.0.1:GetInstalledCertificateIds.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -3144,7 +3144,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetLocalListVersion.req",
+        "$id": "urn:ocpp2.0.1:GetLocalListVersion.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -3170,7 +3170,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetLocalListVersion.conf",
+        "$id": "urn:ocpp2.0.1:GetLocalListVersion.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -3203,7 +3203,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetLog.req",
+        "$id": "urn:ocpp2.0.1:GetLog.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -3288,7 +3288,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetLog.conf",
+        "$id": "urn:ocpp2.0.1:GetLog.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -3360,7 +3360,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetMonitoringReport.req",
+        "$id": "urn:ocpp2.0.1:GetMonitoringReport.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -3508,7 +3508,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetMonitoringReport.conf",
+        "$id": "urn:ocpp2.0.1:GetMonitoringReport.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -3576,7 +3576,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetReport.req",
+        "$id": "urn:ocpp2.0.1:GetReport.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -3725,7 +3725,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetReport.conf",
+        "$id": "urn:ocpp2.0.1:GetReport.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -3793,7 +3793,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetTransactionStatus.req",
+        "$id": "urn:ocpp2.0.1:GetTransactionStatus.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -3824,7 +3824,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetTransactionStatus.conf",
+        "$id": "urn:ocpp2.0.1:GetTransactionStatus.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -3861,7 +3861,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetVariables.req",
+        "$id": "urn:ocpp2.0.1:GetVariables.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -4002,7 +4002,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:GetVariables.conf",
+        "$id": "urn:ocpp2.0.1:GetVariables.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -4189,7 +4189,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:Heartbeat.req",
+        "$id": "urn:ocpp2.0.1:Heartbeat.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -4215,7 +4215,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:Heartbeat.conf",
+        "$id": "urn:ocpp2.0.1:Heartbeat.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -4249,7 +4249,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:InstallCertificate.req",
+        "$id": "urn:ocpp2.0.1:InstallCertificate.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -4297,7 +4297,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:InstallCertificate.conf",
+        "$id": "urn:ocpp2.0.1:InstallCertificate.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -4364,7 +4364,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:LogStatusNotification.req",
+        "$id": "urn:ocpp2.0.1:LogStatusNotification.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -4414,7 +4414,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:LogStatusNotification.conf",
+        "$id": "urn:ocpp2.0.1:LogStatusNotification.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -4440,7 +4440,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:MeterValues.req",
+        "$id": "urn:ocpp2.0.1:MeterValues.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -4677,7 +4677,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:MeterValues.conf",
+        "$id": "urn:ocpp2.0.1:MeterValues.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -4703,7 +4703,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:NotifyChargingLimit.req",
+        "$id": "urn:ocpp2.0.1:NotifyChargingLimit.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -5010,7 +5010,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:NotifyChargingLimit.conf",
+        "$id": "urn:ocpp2.0.1:NotifyChargingLimit.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -5036,7 +5036,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:NotifyCustomerInformation.req",
+        "$id": "urn:ocpp2.0.1:NotifyCustomerInformation.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -5091,7 +5091,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:NotifyCustomerInformation.conf",
+        "$id": "urn:ocpp2.0.1:NotifyCustomerInformation.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -5117,7 +5117,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:NotifyDisplayMessages.req",
+        "$id": "urn:ocpp2.0.1:NotifyDisplayMessages.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -5312,7 +5312,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:NotifyDisplayMessages.conf",
+        "$id": "urn:ocpp2.0.1:NotifyDisplayMessages.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -5338,7 +5338,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:NotifyEVChargingNeeds.req",
+        "$id": "urn:ocpp2.0.1:NotifyEVChargingNeeds.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -5500,7 +5500,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:NotifyEVChargingNeeds.conf",
+        "$id": "urn:ocpp2.0.1:NotifyEVChargingNeeds.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -5567,7 +5567,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:NotifyEVChargingSchedule.req",
+        "$id": "urn:ocpp2.0.1:NotifyEVChargingSchedule.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -5843,7 +5843,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:NotifyEVChargingSchedule.conf",
+        "$id": "urn:ocpp2.0.1:NotifyEVChargingSchedule.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -5909,7 +5909,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:NotifyEvent.req",
+        "$id": "urn:ocpp2.0.1:NotifyEvent.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -6123,7 +6123,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:NotifyEvent.conf",
+        "$id": "urn:ocpp2.0.1:NotifyEvent.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -6149,7 +6149,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:NotifyMonitoringReport.req",
+        "$id": "urn:ocpp2.0.1:NotifyMonitoringReport.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -6352,7 +6352,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:NotifyMonitoringReport.conf",
+        "$id": "urn:ocpp2.0.1:NotifyMonitoringReport.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -6378,7 +6378,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:NotifyReport.req",
+        "$id": "urn:ocpp2.0.1:NotifyReport.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -6643,7 +6643,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:NotifyReport.conf",
+        "$id": "urn:ocpp2.0.1:NotifyReport.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -6669,7 +6669,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:PublishFirmware.req",
+        "$id": "urn:ocpp2.0.1:PublishFirmware.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -6722,7 +6722,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:PublishFirmware.conf",
+        "$id": "urn:ocpp2.0.1:PublishFirmware.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -6788,7 +6788,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:PublishFirmwareStatusNotification.req",
+        "$id": "urn:ocpp2.0.1:PublishFirmwareStatusNotification.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -6850,7 +6850,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:PublishFirmwareStatusNotification.conf",
+        "$id": "urn:ocpp2.0.1:PublishFirmwareStatusNotification.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -6876,7 +6876,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ReportChargingProfiles.req",
+        "$id": "urn:ocpp2.0.1:ReportChargingProfiles.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -7260,7 +7260,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ReportChargingProfiles.conf",
+        "$id": "urn:ocpp2.0.1:ReportChargingProfiles.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -7286,7 +7286,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:RequestStartTransaction.req",
+        "$id": "urn:ocpp2.0.1:RequestStartTransaction.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -7719,7 +7719,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:RequestStartTransaction.conf",
+        "$id": "urn:ocpp2.0.1:RequestStartTransaction.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -7790,7 +7790,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:RequestStopTransaction.req",
+        "$id": "urn:ocpp2.0.1:RequestStopTransaction.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -7824,7 +7824,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:RequestStopTransaction.conf",
+        "$id": "urn:ocpp2.0.1:RequestStopTransaction.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -7890,7 +7890,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ReservationStatusUpdate.req",
+        "$id": "urn:ocpp2.0.1:ReservationStatusUpdate.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -7935,7 +7935,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ReservationStatusUpdate.conf",
+        "$id": "urn:ocpp2.0.1:ReservationStatusUpdate.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -7961,7 +7961,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ReserveNow.req",
+        "$id": "urn:ocpp2.0.1:ReserveNow.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -8110,7 +8110,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:ReserveNow.conf",
+        "$id": "urn:ocpp2.0.1:ReserveNow.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -8179,7 +8179,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:Reset.req",
+        "$id": "urn:ocpp2.0.1:Reset.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -8223,7 +8223,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:Reset.conf",
+        "$id": "urn:ocpp2.0.1:Reset.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -8290,7 +8290,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SecurityEventNotification.req",
+        "$id": "urn:ocpp2.0.1:SecurityEventNotification.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -8335,7 +8335,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SecurityEventNotification.conf",
+        "$id": "urn:ocpp2.0.1:SecurityEventNotification.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -8361,7 +8361,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SendLocalList.req",
+        "$id": "urn:ocpp2.0.1:SendLocalList.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -8604,7 +8604,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SendLocalList.conf",
+        "$id": "urn:ocpp2.0.1:SendLocalList.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -8671,7 +8671,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SetChargingProfile.req",
+        "$id": "urn:ocpp2.0.1:SetChargingProfile.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -9026,7 +9026,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SetChargingProfile.conf",
+        "$id": "urn:ocpp2.0.1:SetChargingProfile.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -9092,7 +9092,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SetDisplayMessage.req",
+        "$id": "urn:ocpp2.0.1:SetDisplayMessage.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -9273,7 +9273,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SetDisplayMessage.conf",
+        "$id": "urn:ocpp2.0.1:SetDisplayMessage.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -9343,7 +9343,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SetMonitoringBase.req",
+        "$id": "urn:ocpp2.0.1:SetMonitoringBase.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -9384,7 +9384,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SetMonitoringBase.conf",
+        "$id": "urn:ocpp2.0.1:SetMonitoringBase.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -9452,7 +9452,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SetMonitoringLevel.req",
+        "$id": "urn:ocpp2.0.1:SetMonitoringLevel.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -9485,7 +9485,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SetMonitoringLevel.conf",
+        "$id": "urn:ocpp2.0.1:SetMonitoringLevel.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -9551,7 +9551,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SetNetworkProfile.req",
+        "$id": "urn:ocpp2.0.1:SetNetworkProfile.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -9777,7 +9777,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SetNetworkProfile.conf",
+        "$id": "urn:ocpp2.0.1:SetNetworkProfile.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -9844,7 +9844,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SetVariableMonitoring.req",
+        "$id": "urn:ocpp2.0.1:SetVariableMonitoring.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -10005,7 +10005,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SetVariableMonitoring.conf",
+        "$id": "urn:ocpp2.0.1:SetVariableMonitoring.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -10198,7 +10198,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SetVariables.req",
+        "$id": "urn:ocpp2.0.1:SetVariables.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -10344,7 +10344,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SetVariables.conf",
+        "$id": "urn:ocpp2.0.1:SetVariables.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -10526,7 +10526,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SignCertificate.req",
+        "$id": "urn:ocpp2.0.1:SignCertificate.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -10571,7 +10571,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:SignCertificate.conf",
+        "$id": "urn:ocpp2.0.1:SignCertificate.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -10637,7 +10637,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:StatusNotification.req",
+        "$id": "urn:ocpp2.0.1:StatusNotification.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -10696,7 +10696,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:StatusNotification.conf",
+        "$id": "urn:ocpp2.0.1:StatusNotification.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -10722,7 +10722,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:TransactionEvent.req",
+        "$id": "urn:ocpp2.0.1:TransactionEvent.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -11191,7 +11191,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:TransactionEvent.conf",
+        "$id": "urn:ocpp2.0.1:TransactionEvent.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -11402,7 +11402,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:TriggerMessage.req",
+        "$id": "urn:ocpp2.0.1:TriggerMessage.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -11475,7 +11475,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:TriggerMessage.conf",
+        "$id": "urn:ocpp2.0.1:TriggerMessage.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -11542,7 +11542,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:UnlockConnector.req",
+        "$id": "urn:ocpp2.0.1:UnlockConnector.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -11580,7 +11580,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:UnlockConnector.conf",
+        "$id": "urn:ocpp2.0.1:UnlockConnector.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -11648,7 +11648,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:UnpublishFirmware.req",
+        "$id": "urn:ocpp2.0.1:UnpublishFirmware.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -11682,7 +11682,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:UnpublishFirmware.conf",
+        "$id": "urn:ocpp2.0.1:UnpublishFirmware.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -11723,7 +11723,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:UpdateFirmware.req",
+        "$id": "urn:ocpp2.0.1:UpdateFirmware.req",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {
@@ -11807,7 +11807,7 @@
         "type": "object"
     },
     {
-        "$id": "urn:UpdateFirmware.conf",
+        "$id": "urn:ocpp2.0.1:UpdateFirmware.conf",
         "$schema": "http://json-schema.org/draft-07/schema",
         "additionalProperties": false,
         "definitions": {

--- a/lib/schemas/ocpp2_1.json
+++ b/lib/schemas/ocpp2_1.json
@@ -1,7 +1,7 @@
 [
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:AdjustPeriodicEventStreamRequest",
+        "$id": "urn:ocpp2.1:AdjustPeriodicEventStreamRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "PeriodicEventStreamParamsType": {
@@ -60,7 +60,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:AdjustPeriodicEventStreamResponse",
+        "$id": "urn:ocpp2.1:AdjustPeriodicEventStreamResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "GenericStatusEnumType": {
@@ -131,7 +131,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:AFRRSignalRequest",
+        "$id": "urn:ocpp2.1:AFRRSignalRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -172,7 +172,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:AFRRSignalResponse",
+        "$id": "urn:ocpp2.1:AFRRSignalResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "GenericStatusEnumType": {
@@ -242,7 +242,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:AuthorizeRequest",
+        "$id": "urn:ocpp2.1:AuthorizeRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "HashAlgorithmEnumType": {
@@ -400,7 +400,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:AuthorizeResponse",
+        "$id": "urn:ocpp2.1:AuthorizeResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "AuthorizationStatusEnumType": {
@@ -1088,7 +1088,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:BatterySwapRequest",
+        "$id": "urn:ocpp2.1:BatterySwapRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "BatterySwapEventEnumType": {
@@ -1257,7 +1257,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:BatterySwapResponse",
+        "$id": "urn:ocpp2.1:BatterySwapResponse",
         "description": "This is an empty response that just acknowledges receipt of the request. (The request cannot be rejected).\r\n",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
@@ -1286,7 +1286,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:BootNotificationRequest",
+        "$id": "urn:ocpp2.1:BootNotificationRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "BootReasonEnumType": {
@@ -1400,7 +1400,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:BootNotificationResponse",
+        "$id": "urn:ocpp2.1:BootNotificationResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "RegistrationStatusEnumType": {
@@ -1483,7 +1483,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:CancelReservationRequest",
+        "$id": "urn:ocpp2.1:CancelReservationRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -1519,7 +1519,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:CancelReservationResponse",
+        "$id": "urn:ocpp2.1:CancelReservationResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CancelReservationStatusEnumType": {
@@ -1590,7 +1590,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:CertificateSignedRequest",
+        "$id": "urn:ocpp2.1:CertificateSignedRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CertificateSigningUseEnumType": {
@@ -1644,7 +1644,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:CertificateSignedResponse",
+        "$id": "urn:ocpp2.1:CertificateSignedResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CertificateSignedStatusEnumType": {
@@ -1715,7 +1715,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ChangeAvailabilityRequest",
+        "$id": "urn:ocpp2.1:ChangeAvailabilityRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "OperationalStatusEnumType": {
@@ -1786,7 +1786,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ChangeAvailabilityResponse",
+        "$id": "urn:ocpp2.1:ChangeAvailabilityResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ChangeAvailabilityStatusEnumType": {
@@ -1858,7 +1858,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ChangeTransactionTariffRequest",
+        "$id": "urn:ocpp2.1:ChangeTransactionTariffRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "DayOfWeekEnumType": {
@@ -2376,7 +2376,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ChangeTransactionTariffResponse",
+        "$id": "urn:ocpp2.1:ChangeTransactionTariffResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "TariffChangeStatusEnumType": {
@@ -2451,7 +2451,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ClearCacheRequest",
+        "$id": "urn:ocpp2.1:ClearCacheRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -2479,7 +2479,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ClearCacheResponse",
+        "$id": "urn:ocpp2.1:ClearCacheResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ClearCacheStatusEnumType": {
@@ -2550,7 +2550,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ClearChargingProfileRequest",
+        "$id": "urn:ocpp2.1:ClearChargingProfileRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ChargingProfilePurposeEnumType": {
@@ -2623,7 +2623,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ClearChargingProfileResponse",
+        "$id": "urn:ocpp2.1:ClearChargingProfileResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ClearChargingProfileStatusEnumType": {
@@ -2694,7 +2694,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ClearDERControlRequest",
+        "$id": "urn:ocpp2.1:ClearDERControlRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "DERControlEnumType": {
@@ -2767,7 +2767,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ClearDERControlResponse",
+        "$id": "urn:ocpp2.1:ClearDERControlResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "DERControlStatusEnumType": {
@@ -2840,7 +2840,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ClearDisplayMessageRequest",
+        "$id": "urn:ocpp2.1:ClearDisplayMessageRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -2876,7 +2876,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ClearDisplayMessageResponse",
+        "$id": "urn:ocpp2.1:ClearDisplayMessageResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ClearMessageStatusEnumType": {
@@ -2948,7 +2948,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ClearedChargingLimitRequest",
+        "$id": "urn:ocpp2.1:ClearedChargingLimitRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -2989,7 +2989,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ClearedChargingLimitResponse",
+        "$id": "urn:ocpp2.1:ClearedChargingLimitResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -3017,7 +3017,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ClearTariffsRequest",
+        "$id": "urn:ocpp2.1:ClearTariffsRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -3060,7 +3060,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ClearTariffsResponse",
+        "$id": "urn:ocpp2.1:ClearTariffsResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "TariffClearStatusEnumType": {
@@ -3157,7 +3157,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ClearVariableMonitoringRequest",
+        "$id": "urn:ocpp2.1:ClearVariableMonitoringRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -3198,7 +3198,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ClearVariableMonitoringResponse",
+        "$id": "urn:ocpp2.1:ClearVariableMonitoringResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ClearMonitoringStatusEnumType": {
@@ -3297,7 +3297,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ClosePeriodicEventStreamRequest",
+        "$id": "urn:ocpp2.1:ClosePeriodicEventStreamRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -3333,7 +3333,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ClosePeriodicEventStreamResponse",
+        "$id": "urn:ocpp2.1:ClosePeriodicEventStreamResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -3361,7 +3361,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:CostUpdatedRequest",
+        "$id": "urn:ocpp2.1:CostUpdatedRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -3402,7 +3402,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:CostUpdatedResponse",
+        "$id": "urn:ocpp2.1:CostUpdatedResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -3430,7 +3430,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:CustomerInformationRequest",
+        "$id": "urn:ocpp2.1:CustomerInformationRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "HashAlgorithmEnumType": {
@@ -3590,7 +3590,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:CustomerInformationResponse",
+        "$id": "urn:ocpp2.1:CustomerInformationResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomerInformationStatusEnumType": {
@@ -3662,7 +3662,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:DataTransferRequest",
+        "$id": "urn:ocpp2.1:DataTransferRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -3706,7 +3706,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:DataTransferResponse",
+        "$id": "urn:ocpp2.1:DataTransferResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "DataTransferStatusEnumType": {
@@ -3782,7 +3782,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:DeleteCertificateRequest",
+        "$id": "urn:ocpp2.1:DeleteCertificateRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "HashAlgorithmEnumType": {
@@ -3861,7 +3861,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:DeleteCertificateResponse",
+        "$id": "urn:ocpp2.1:DeleteCertificateResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "DeleteCertificateStatusEnumType": {
@@ -3933,7 +3933,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:FirmwareStatusNotificationRequest",
+        "$id": "urn:ocpp2.1:FirmwareStatusNotificationRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "FirmwareStatusEnumType": {
@@ -4020,7 +4020,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:FirmwareStatusNotificationResponse",
+        "$id": "urn:ocpp2.1:FirmwareStatusNotificationResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -4048,7 +4048,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:Get15118EVCertificateRequest",
+        "$id": "urn:ocpp2.1:Get15118EVCertificateRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CertificateActionEnumType": {
@@ -4120,7 +4120,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:Get15118EVCertificateResponse",
+        "$id": "urn:ocpp2.1:Get15118EVCertificateResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "Iso15118EVCertificateStatusEnumType": {
@@ -4202,7 +4202,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetBaseReportRequest",
+        "$id": "urn:ocpp2.1:GetBaseReportRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ReportBaseEnumType": {
@@ -4252,7 +4252,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetBaseReportResponse",
+        "$id": "urn:ocpp2.1:GetBaseReportResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "GenericDeviceModelStatusEnumType": {
@@ -4325,7 +4325,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetCertificateChainStatusRequest",
+        "$id": "urn:ocpp2.1:GetCertificateChainStatusRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CertificateStatusSourceEnumType": {
@@ -4453,7 +4453,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetCertificateChainStatusResponse",
+        "$id": "urn:ocpp2.1:GetCertificateChainStatusResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CertificateStatusEnumType": {
@@ -4590,7 +4590,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetCertificateStatusRequest",
+        "$id": "urn:ocpp2.1:GetCertificateStatusRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "HashAlgorithmEnumType": {
@@ -4676,7 +4676,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetCertificateStatusResponse",
+        "$id": "urn:ocpp2.1:GetCertificateStatusResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "GetCertificateStatusEnumType": {
@@ -4752,7 +4752,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetChargingProfilesRequest",
+        "$id": "urn:ocpp2.1:GetChargingProfilesRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ChargingProfilePurposeEnumType": {
@@ -4849,7 +4849,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetChargingProfilesResponse",
+        "$id": "urn:ocpp2.1:GetChargingProfilesResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "GetChargingProfileStatusEnumType": {
@@ -4920,7 +4920,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetCompositeScheduleRequest",
+        "$id": "urn:ocpp2.1:GetCompositeScheduleRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ChargingRateUnitEnumType": {
@@ -4974,7 +4974,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetCompositeScheduleResponse",
+        "$id": "urn:ocpp2.1:GetCompositeScheduleResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ChargingRateUnitEnumType": {
@@ -5272,7 +5272,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetDERControlRequest",
+        "$id": "urn:ocpp2.1:GetDERControlRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "DERControlEnumType": {
@@ -5349,7 +5349,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetDERControlResponse",
+        "$id": "urn:ocpp2.1:GetDERControlResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "DERControlStatusEnumType": {
@@ -5422,7 +5422,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetDisplayMessagesRequest",
+        "$id": "urn:ocpp2.1:GetDisplayMessagesRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "MessagePriorityEnumType": {
@@ -5498,7 +5498,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetDisplayMessagesResponse",
+        "$id": "urn:ocpp2.1:GetDisplayMessagesResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "GetDisplayMessagesStatusEnumType": {
@@ -5569,7 +5569,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetInstalledCertificateIdsRequest",
+        "$id": "urn:ocpp2.1:GetInstalledCertificateIdsRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "GetCertificateIdUseEnumType": {
@@ -5619,7 +5619,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetInstalledCertificateIdsResponse",
+        "$id": "urn:ocpp2.1:GetInstalledCertificateIdsResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "GetCertificateIdUseEnumType": {
@@ -5786,7 +5786,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetLocalListVersionRequest",
+        "$id": "urn:ocpp2.1:GetLocalListVersionRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -5814,7 +5814,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetLocalListVersionResponse",
+        "$id": "urn:ocpp2.1:GetLocalListVersionResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -5849,7 +5849,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetLogRequest",
+        "$id": "urn:ocpp2.1:GetLogRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "LogEnumType": {
@@ -5941,7 +5941,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetLogResponse",
+        "$id": "urn:ocpp2.1:GetLogResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "LogStatusEnumType": {
@@ -6018,7 +6018,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetMonitoringReportRequest",
+        "$id": "urn:ocpp2.1:GetMonitoringReportRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "MonitoringCriterionEnumType": {
@@ -6176,7 +6176,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetMonitoringReportResponse",
+        "$id": "urn:ocpp2.1:GetMonitoringReportResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "GenericDeviceModelStatusEnumType": {
@@ -6249,7 +6249,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetPeriodicEventStreamRequest",
+        "$id": "urn:ocpp2.1:GetPeriodicEventStreamRequest",
         "description": "This message is empty. It has no fields.\r\n",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
@@ -6278,7 +6278,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetPeriodicEventStreamResponse",
+        "$id": "urn:ocpp2.1:GetPeriodicEventStreamResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ConstantStreamDataType": {
@@ -6362,7 +6362,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetReportRequest",
+        "$id": "urn:ocpp2.1:GetReportRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ComponentCriterionEnumType": {
@@ -6521,7 +6521,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetReportResponse",
+        "$id": "urn:ocpp2.1:GetReportResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "GenericDeviceModelStatusEnumType": {
@@ -6594,7 +6594,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetTariffsRequest",
+        "$id": "urn:ocpp2.1:GetTariffsRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -6630,7 +6630,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetTariffsResponse",
+        "$id": "urn:ocpp2.1:GetTariffsResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "TariffGetStatusEnumType": {
@@ -6767,7 +6767,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetTransactionStatusRequest",
+        "$id": "urn:ocpp2.1:GetTransactionStatusRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -6800,7 +6800,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetTransactionStatusResponse",
+        "$id": "urn:ocpp2.1:GetTransactionStatusResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -6839,7 +6839,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetVariablesRequest",
+        "$id": "urn:ocpp2.1:GetVariablesRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "AttributeEnumType": {
@@ -6990,7 +6990,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:GetVariablesResponse",
+        "$id": "urn:ocpp2.1:GetVariablesResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "AttributeEnumType": {
@@ -7188,7 +7188,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:HeartbeatRequest",
+        "$id": "urn:ocpp2.1:HeartbeatRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -7216,7 +7216,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:HeartbeatResponse",
+        "$id": "urn:ocpp2.1:HeartbeatResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -7252,7 +7252,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:InstallCertificateRequest",
+        "$id": "urn:ocpp2.1:InstallCertificateRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "InstallCertificateUseEnumType": {
@@ -7305,7 +7305,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:InstallCertificateResponse",
+        "$id": "urn:ocpp2.1:InstallCertificateResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "InstallCertificateStatusEnumType": {
@@ -7377,7 +7377,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:LogStatusNotificationRequest",
+        "$id": "urn:ocpp2.1:LogStatusNotificationRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "UploadLogStatusEnumType": {
@@ -7458,7 +7458,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:LogStatusNotificationResponse",
+        "$id": "urn:ocpp2.1:LogStatusNotificationResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -7486,7 +7486,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:MeterValuesRequest",
+        "$id": "urn:ocpp2.1:MeterValuesRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "LocationEnumType": {
@@ -7767,7 +7767,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:MeterValuesResponse",
+        "$id": "urn:ocpp2.1:MeterValuesResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -7795,7 +7795,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyAllowedEnergyTransferRequest",
+        "$id": "urn:ocpp2.1:NotifyAllowedEnergyTransferRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "EnergyTransferModeEnumType": {
@@ -7859,7 +7859,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyAllowedEnergyTransferResponse",
+        "$id": "urn:ocpp2.1:NotifyAllowedEnergyTransferResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "NotifyAllowedEnergyTransferStatusEnumType": {
@@ -7929,7 +7929,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyChargingLimitRequest",
+        "$id": "urn:ocpp2.1:NotifyChargingLimitRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ChargingRateUnitEnumType": {
@@ -8826,7 +8826,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyChargingLimitResponse",
+        "$id": "urn:ocpp2.1:NotifyChargingLimitResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -8854,7 +8854,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyCustomerInformationRequest",
+        "$id": "urn:ocpp2.1:NotifyCustomerInformationRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -8913,7 +8913,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyCustomerInformationResponse",
+        "$id": "urn:ocpp2.1:NotifyCustomerInformationResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -8941,7 +8941,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyDERAlarmRequest",
+        "$id": "urn:ocpp2.1:NotifyDERAlarmRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "DERControlEnumType": {
@@ -9042,7 +9042,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyDERAlarmResponse",
+        "$id": "urn:ocpp2.1:NotifyDERAlarmResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -9070,7 +9070,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyDERStartStopRequest",
+        "$id": "urn:ocpp2.1:NotifyDERStartStopRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -9128,7 +9128,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyDERStartStopResponse",
+        "$id": "urn:ocpp2.1:NotifyDERStartStopResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -9156,7 +9156,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyDisplayMessagesRequest",
+        "$id": "urn:ocpp2.1:NotifyDisplayMessagesRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "MessageFormatEnumType": {
@@ -9378,7 +9378,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyDisplayMessagesResponse",
+        "$id": "urn:ocpp2.1:NotifyDisplayMessagesResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -9406,7 +9406,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyEVChargingNeedsRequest",
+        "$id": "urn:ocpp2.1:NotifyEVChargingNeedsRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ControlModeEnumType": {
@@ -10146,7 +10146,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyEVChargingNeedsResponse",
+        "$id": "urn:ocpp2.1:NotifyEVChargingNeedsResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "NotifyEVChargingNeedsStatusEnumType": {
@@ -10219,7 +10219,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyEVChargingScheduleRequest",
+        "$id": "urn:ocpp2.1:NotifyEVChargingScheduleRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ChargingRateUnitEnumType": {
@@ -11098,7 +11098,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyEVChargingScheduleResponse",
+        "$id": "urn:ocpp2.1:NotifyEVChargingScheduleResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "GenericStatusEnumType": {
@@ -11169,7 +11169,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyEventRequest",
+        "$id": "urn:ocpp2.1:NotifyEventRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "EventNotificationEnumType": {
@@ -11404,7 +11404,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyEventResponse",
+        "$id": "urn:ocpp2.1:NotifyEventResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -11432,7 +11432,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyMonitoringReportRequest",
+        "$id": "urn:ocpp2.1:NotifyMonitoringReportRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "EventNotificationEnumType": {
@@ -11667,7 +11667,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyMonitoringReportResponse",
+        "$id": "urn:ocpp2.1:NotifyMonitoringReportResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -11695,7 +11695,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyPeriodicEventStream",
+        "$id": "urn:ocpp2.1:NotifyPeriodicEventStream",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "StreamDataElementType": {
@@ -11774,7 +11774,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyPriorityChargingRequest",
+        "$id": "urn:ocpp2.1:NotifyPriorityChargingRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -11815,7 +11815,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyPriorityChargingResponse",
+        "$id": "urn:ocpp2.1:NotifyPriorityChargingResponse",
         "description": "This response message has an empty body.\r\n",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
@@ -11844,7 +11844,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyReportRequest",
+        "$id": "urn:ocpp2.1:NotifyReportRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "AttributeEnumType": {
@@ -12131,7 +12131,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyReportResponse",
+        "$id": "urn:ocpp2.1:NotifyReportResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -12159,7 +12159,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifySettlementRequest",
+        "$id": "urn:ocpp2.1:NotifySettlementRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "PaymentStatusEnumType": {
@@ -12296,7 +12296,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifySettlementResponse",
+        "$id": "urn:ocpp2.1:NotifySettlementResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -12334,7 +12334,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyWebPaymentStartedRequest",
+        "$id": "urn:ocpp2.1:NotifyWebPaymentStartedRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -12375,7 +12375,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:NotifyWebPaymentStartedResponse",
+        "$id": "urn:ocpp2.1:NotifyWebPaymentStartedResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -12403,7 +12403,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:OpenPeriodicEventStreamRequest",
+        "$id": "urn:ocpp2.1:OpenPeriodicEventStreamRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ConstantStreamDataType": {
@@ -12485,7 +12485,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:OpenPeriodicEventStreamResponse",
+        "$id": "urn:ocpp2.1:OpenPeriodicEventStreamResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "GenericStatusEnumType": {
@@ -12556,7 +12556,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:PublishFirmwareRequest",
+        "$id": "urn:ocpp2.1:PublishFirmwareRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -12614,7 +12614,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:PublishFirmwareResponse",
+        "$id": "urn:ocpp2.1:PublishFirmwareResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "GenericStatusEnumType": {
@@ -12685,7 +12685,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:PublishFirmwareStatusNotificationRequest",
+        "$id": "urn:ocpp2.1:PublishFirmwareStatusNotificationRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "PublishFirmwareStatusEnumType": {
@@ -12779,7 +12779,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:PublishFirmwareStatusNotificationResponse",
+        "$id": "urn:ocpp2.1:PublishFirmwareStatusNotificationResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -12807,7 +12807,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:PullDynamicScheduleUpdateRequest",
+        "$id": "urn:ocpp2.1:PullDynamicScheduleUpdateRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -12842,7 +12842,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:PullDynamicScheduleUpdateResponse",
+        "$id": "urn:ocpp2.1:PullDynamicScheduleUpdateResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ChargingProfileStatusEnumType": {
@@ -12978,7 +12978,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ReportChargingProfilesRequest",
+        "$id": "urn:ocpp2.1:ReportChargingProfilesRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ChargingProfileKindEnumType": {
@@ -13981,7 +13981,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ReportChargingProfilesResponse",
+        "$id": "urn:ocpp2.1:ReportChargingProfilesResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -14009,7 +14009,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ReportDERControlRequest",
+        "$id": "urn:ocpp2.1:ReportDERControlRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "DERControlEnumType": {
@@ -14764,7 +14764,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ReportDERControlResponse",
+        "$id": "urn:ocpp2.1:ReportDERControlResponse",
         "description": "This message has no parameters.\r\n\r\n",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
@@ -14793,7 +14793,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:RequestBatterySwapRequest",
+        "$id": "urn:ocpp2.1:RequestBatterySwapRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "AdditionalInfoType": {
@@ -14890,7 +14890,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:RequestBatterySwapResponse",
+        "$id": "urn:ocpp2.1:RequestBatterySwapResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "GenericStatusEnumType": {
@@ -14961,7 +14961,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:RequestStartTransactionRequest",
+        "$id": "urn:ocpp2.1:RequestStartTransactionRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ChargingProfileKindEnumType": {
@@ -16011,7 +16011,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:RequestStartTransactionResponse",
+        "$id": "urn:ocpp2.1:RequestStartTransactionResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "RequestStartStopStatusEnumType": {
@@ -16087,7 +16087,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:RequestStopTransactionRequest",
+        "$id": "urn:ocpp2.1:RequestStopTransactionRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -16123,7 +16123,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:RequestStopTransactionResponse",
+        "$id": "urn:ocpp2.1:RequestStopTransactionResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "RequestStartStopStatusEnumType": {
@@ -16194,7 +16194,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ReservationStatusUpdateRequest",
+        "$id": "urn:ocpp2.1:ReservationStatusUpdateRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ReservationUpdateStatusEnumType": {
@@ -16245,7 +16245,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ReservationStatusUpdateResponse",
+        "$id": "urn:ocpp2.1:ReservationStatusUpdateResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -16273,7 +16273,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ReserveNowRequest",
+        "$id": "urn:ocpp2.1:ReserveNowRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "AdditionalInfoType": {
@@ -16390,7 +16390,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ReserveNowResponse",
+        "$id": "urn:ocpp2.1:ReserveNowResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ReserveNowStatusEnumType": {
@@ -16464,7 +16464,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ResetRequest",
+        "$id": "urn:ocpp2.1:ResetRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ResetEnumType": {
@@ -16514,7 +16514,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:ResetResponse",
+        "$id": "urn:ocpp2.1:ResetResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ResetStatusEnumType": {
@@ -16586,7 +16586,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SecurityEventNotificationRequest",
+        "$id": "urn:ocpp2.1:SecurityEventNotificationRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -16633,7 +16633,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SecurityEventNotificationResponse",
+        "$id": "urn:ocpp2.1:SecurityEventNotificationResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -16661,7 +16661,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SendLocalListRequest",
+        "$id": "urn:ocpp2.1:SendLocalListRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "AuthorizationStatusEnumType": {
@@ -16907,7 +16907,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SendLocalListResponse",
+        "$id": "urn:ocpp2.1:SendLocalListResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "SendLocalListStatusEnumType": {
@@ -16979,7 +16979,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SetChargingProfileRequest",
+        "$id": "urn:ocpp2.1:SetChargingProfileRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ChargingProfileKindEnumType": {
@@ -17961,7 +17961,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SetChargingProfileResponse",
+        "$id": "urn:ocpp2.1:SetChargingProfileResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ChargingProfileStatusEnumType": {
@@ -18032,7 +18032,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SetDefaultTariffRequest",
+        "$id": "urn:ocpp2.1:SetDefaultTariffRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "DayOfWeekEnumType": {
@@ -18550,7 +18550,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SetDefaultTariffResponse",
+        "$id": "urn:ocpp2.1:SetDefaultTariffResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "TariffSetStatusEnumType": {
@@ -18623,7 +18623,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SetDERControlRequest",
+        "$id": "urn:ocpp2.1:SetDERControlRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "DERControlEnumType": {
@@ -19128,7 +19128,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SetDERControlResponse",
+        "$id": "urn:ocpp2.1:SetDERControlResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "DERControlStatusEnumType": {
@@ -19212,7 +19212,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SetDisplayMessageRequest",
+        "$id": "urn:ocpp2.1:SetDisplayMessageRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "MessageFormatEnumType": {
@@ -19420,7 +19420,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SetDisplayMessageResponse",
+        "$id": "urn:ocpp2.1:SetDisplayMessageResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "DisplayMessageStatusEnumType": {
@@ -19496,7 +19496,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SetMonitoringBaseRequest",
+        "$id": "urn:ocpp2.1:SetMonitoringBaseRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "MonitoringBaseEnumType": {
@@ -19541,7 +19541,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SetMonitoringBaseResponse",
+        "$id": "urn:ocpp2.1:SetMonitoringBaseResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "GenericDeviceModelStatusEnumType": {
@@ -19614,7 +19614,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SetMonitoringLevelRequest",
+        "$id": "urn:ocpp2.1:SetMonitoringLevelRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -19650,7 +19650,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SetMonitoringLevelResponse",
+        "$id": "urn:ocpp2.1:SetMonitoringLevelResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "GenericStatusEnumType": {
@@ -19721,7 +19721,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SetNetworkProfileRequest",
+        "$id": "urn:ocpp2.1:SetNetworkProfileRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "APNAuthenticationEnumType": {
@@ -19975,7 +19975,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SetNetworkProfileResponse",
+        "$id": "urn:ocpp2.1:SetNetworkProfileResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "SetNetworkProfileStatusEnumType": {
@@ -20047,7 +20047,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SetVariableMonitoringRequest",
+        "$id": "urn:ocpp2.1:SetVariableMonitoringRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "MonitorEnumType": {
@@ -20245,7 +20245,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SetVariableMonitoringResponse",
+        "$id": "urn:ocpp2.1:SetVariableMonitoringResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "MonitorEnumType": {
@@ -20455,7 +20455,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SetVariablesRequest",
+        "$id": "urn:ocpp2.1:SetVariablesRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "AttributeEnumType": {
@@ -20611,7 +20611,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SetVariablesResponse",
+        "$id": "urn:ocpp2.1:SetVariablesResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "AttributeEnumType": {
@@ -20806,7 +20806,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SignCertificateRequest",
+        "$id": "urn:ocpp2.1:SignCertificateRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CertificateSigningUseEnumType": {
@@ -20908,7 +20908,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:SignCertificateResponse",
+        "$id": "urn:ocpp2.1:SignCertificateResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "GenericStatusEnumType": {
@@ -20979,7 +20979,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:StatusNotificationRequest",
+        "$id": "urn:ocpp2.1:StatusNotificationRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ConnectorStatusEnumType": {
@@ -21044,7 +21044,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:StatusNotificationResponse",
+        "$id": "urn:ocpp2.1:StatusNotificationResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -21072,7 +21072,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:TransactionEventRequest",
+        "$id": "urn:ocpp2.1:TransactionEventRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ChargingStateEnumType": {
@@ -21947,7 +21947,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:TransactionEventResponse",
+        "$id": "urn:ocpp2.1:TransactionEventResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "AuthorizationStatusEnumType": {
@@ -22199,7 +22199,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:TriggerMessageRequest",
+        "$id": "urn:ocpp2.1:TriggerMessageRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "MessageTriggerEnumType": {
@@ -22286,7 +22286,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:TriggerMessageResponse",
+        "$id": "urn:ocpp2.1:TriggerMessageResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "TriggerMessageStatusEnumType": {
@@ -22358,7 +22358,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:UnlockConnectorRequest",
+        "$id": "urn:ocpp2.1:UnlockConnectorRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -22400,7 +22400,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:UnlockConnectorResponse",
+        "$id": "urn:ocpp2.1:UnlockConnectorResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "UnlockStatusEnumType": {
@@ -22473,7 +22473,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:UnpublishFirmwareRequest",
+        "$id": "urn:ocpp2.1:UnpublishFirmwareRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -22509,7 +22509,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:UnpublishFirmwareResponse",
+        "$id": "urn:ocpp2.1:UnpublishFirmwareResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "UnpublishFirmwareStatusEnumType": {
@@ -22554,7 +22554,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:UpdateDynamicScheduleRequest",
+        "$id": "urn:ocpp2.1:UpdateDynamicScheduleRequest",
         "description": "Id of dynamic charging profile to update.\r\n",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
@@ -22656,7 +22656,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:UpdateDynamicScheduleResponse",
+        "$id": "urn:ocpp2.1:UpdateDynamicScheduleResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "ChargingProfileStatusEnumType": {
@@ -22727,7 +22727,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:UpdateFirmwareRequest",
+        "$id": "urn:ocpp2.1:UpdateFirmwareRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "FirmwareType": {
@@ -22815,7 +22815,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:UpdateFirmwareResponse",
+        "$id": "urn:ocpp2.1:UpdateFirmwareResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "UpdateFirmwareStatusEnumType": {
@@ -22889,7 +22889,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:UsePriorityChargingRequest",
+        "$id": "urn:ocpp2.1:UsePriorityChargingRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -22930,7 +22930,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:UsePriorityChargingResponse",
+        "$id": "urn:ocpp2.1:UsePriorityChargingResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "PriorityChargingStatusEnumType": {
@@ -23002,7 +23002,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:VatNumberValidationRequest",
+        "$id": "urn:ocpp2.1:VatNumberValidationRequest",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "CustomDataType": {
@@ -23043,7 +23043,7 @@
     },
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "urn:VatNumberValidationResponse",
+        "$id": "urn:ocpp2.1:VatNumberValidationResponse",
         "comment": "OCPP 2.1 Edition 1 (c) OCA, Creative Commons Attribution-NoDerivatives 4.0 International Public License",
         "definitions": {
             "GenericStatusEnumType": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
-        "ajv": "8.14.0",
+        "ajv": "8.18.0",
         "ajv-formats": "^2.1.1",
         "backoff": "^2.5.0",
         "ws": "^8.5.0"
@@ -61,6 +61,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.0.tgz",
       "integrity": "sha512-Xyw74OlJwDijToNi0+6BBI5mLLR5+5R3bcSH80LXzjzEGEUlvNzujEE71BaD/ApEZHAvFI/Mlmp4M5lIkdeeWw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
@@ -567,14 +568,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.14.0.tgz",
-      "integrity": "sha512-oYs1UUtO97ZO2lJ4bwnWeQW8/zvOIQLGKcvPTsWmvc2SYgBb+upuNS5NxoLaMU4h8Ju3Nbj6Cq8mD2LQoqVKFA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -1027,6 +1029,22 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -2076,14 +2094,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -2380,14 +2390,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
     "node_modules/uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -2599,6 +2601,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.0.tgz",
       "integrity": "sha512-Xyw74OlJwDijToNi0+6BBI5mLLR5+5R3bcSH80LXzjzEGEUlvNzujEE71BaD/ApEZHAvFI/Mlmp4M5lIkdeeWw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
@@ -2993,14 +2996,14 @@
       }
     },
     "ajv": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.14.0.tgz",
-      "integrity": "sha512-oYs1UUtO97ZO2lJ4bwnWeQW8/zvOIQLGKcvPTsWmvc2SYgBb+upuNS5NxoLaMU4h8Ju3Nbj6Cq8mD2LQoqVKFA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
+        "require-from-string": "^2.0.2"
       }
     },
     "ajv-formats": {
@@ -3324,6 +3327,11 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -4093,11 +4101,6 @@
         "fromentries": "^1.2.0"
       }
     },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -4322,14 +4325,6 @@
       "dev": true,
       "requires": {
         "is-typedarray": "^1.0.0"
-      }
-    },
-    "uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "requires": {
-        "punycode": "^2.1.0"
       }
     },
     "uuid": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/mikuso/ocpp-rpc#readme",
   "license": "MIT",
   "dependencies": {
-    "ajv": "8.14.0",
+    "ajv": "8.18.0",
     "ajv-formats": "^2.1.1",
     "backoff": "^2.5.0",
     "ws": "^8.5.0"

--- a/test/client.js
+++ b/test/client.js
@@ -49,7 +49,7 @@ describe('RPCClient', function(){
         return createValidator('echo1.0', [
             {
                 "$schema": "http://json-schema.org/draft-07/schema",
-                "$id": "urn:Echo.req",
+                "$id": "urn:echo1.0:Echo.req",
                 "type": "object",
                 "properties": {
                     "val": {
@@ -61,7 +61,7 @@ describe('RPCClient', function(){
             },
             {
                 "$schema": "http://json-schema.org/draft-07/schema",
-                "$id": "urn:Echo.conf",
+                "$id": "urn:echo1.0:Echo.conf",
                 "type": "object",
                 "properties": {
                     "val": {
@@ -78,7 +78,7 @@ describe('RPCClient', function(){
         return createValidator('numbers1.0', [
             {
                 "$schema": "http://json-schema.org/draft-07/schema",
-                "$id": "urn:TestTenth.req",
+                "$id": "urn:numbers1.0:TestTenth.req",
                 "type": "object",
                 "properties": {
                     "val": {
@@ -91,7 +91,7 @@ describe('RPCClient', function(){
             },
             {
                 "$schema": "http://json-schema.org/draft-07/schema",
-                "$id": "urn:TestTenth.conf",
+                "$id": "urn:numbers1.0:TestTenth.conf",
                 "type": "object",
                 "properties": {
                     "val": {

--- a/test/server-client.js
+++ b/test/server-client.js
@@ -9,7 +9,7 @@ function getEchoValidator() {
     return createValidator('echo1.0', [
         {
             "$schema": "http://json-schema.org/draft-07/schema",
-            "$id": "urn:Echo.req",
+            "$id": "urn:echo1.0:Echo.req",
             "type": "object",
             "properties": {
                 "val": {
@@ -21,7 +21,7 @@ function getEchoValidator() {
         },
         {
             "$schema": "http://json-schema.org/draft-07/schema",
-            "$id": "urn:Echo.conf",
+            "$id": "urn:echo1.0:Echo.conf",
             "type": "object",
             "properties": {
                 "val": {

--- a/test/server.js
+++ b/test/server.js
@@ -42,7 +42,7 @@ describe('RPCServer', function(){
         return createValidator('echo1.0', [
             {
                 "$schema": "http://json-schema.org/draft-07/schema",
-                "$id": "urn:Echo.req",
+                "$id": "urn:echo1.0:Echo.req",
                 "type": "object",
                 "properties": {
                     "val": {
@@ -54,7 +54,7 @@ describe('RPCServer', function(){
             },
             {
                 "$schema": "http://json-schema.org/draft-07/schema",
-                "$id": "urn:Echo.conf",
+                "$id": "urn:echo1.0:Echo.conf",
                 "type": "object",
                 "properties": {
                     "val": {

--- a/test/validator.js
+++ b/test/validator.js
@@ -10,7 +10,7 @@ describe('Validator', function(){
 
             const validator = createValidator('test', [{
                 $schema: "http://json-schema.org/draft-07/schema",
-                $id: "urn:Test.req",
+                $id: "urn:test:Test.req",
                 type: "object",
                 properties: {},
             }]);
@@ -25,7 +25,7 @@ describe('Validator', function(){
             };
 
             assert.throws(() => {
-                validator.validate('urn:Test.req', {});
+                validator.validate('urn:test:Test.req', {});
             }, errors.RPCFormatViolationError);
 
         });


### PR DESCRIPTION
Update the `ajv` version to `8.18.0`

With `ajv 8.15.0`the `uri-js` package was replaced with `fast-uri`. The `fast-uri` library is stricter in validating the schema files, especially for the `$id` attributes which are currently not [RFC 8141](https://datatracker.ietf.org/doc/html/rfc8141) conform, because there is no namespace specifier.
The schema files and the implementation is changed, so the urn namespace specifier is the same as the subprotocol identifier.

Fixes #92