### PR TITLE
[Update] Test-matrix node versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,9 +9,15 @@ jobs:
     strategy:
       matrix:
         nodeVer:
+          # lowest supported release
           - 17.3.0
+          # current release
+          - current
+          # in-between LTS releases
           - 18
-          - 19
+          - 20
+          - 22
+          - 24
     steps:
 
       - uses: actions/checkout@master

--- a/test/client.js
+++ b/test/client.js
@@ -846,7 +846,7 @@ describe('RPCClient', function(){
         });
 
         it('should resolve to the same result when called simultaneously', async () => {
-            
+
             const {endpoint, close, server} = await createServer();
 
             const cli = new RPCClient({
@@ -858,10 +858,9 @@ describe('RPCClient', function(){
                 const c1 = cli.connect();
                 const c2 = cli.connect();
 
-                await c1;
-                await c2;
+                const [r1, r2] = await Promise.all([c1, c2]);
 
-                assert.deepEqual(c1, c2);
+                assert.strictEqual(r1, r2);
 
             } finally {
                 cli.close();


### PR DESCRIPTION
## Problem

`RPCClient #connect should resolve to the same result when called simultaneously` fails on Node **24.15.0** (passes on every prior version, 17 through 24.14.0). CI never caught it because the matrix capped at Node 19.

## Fix

The test compared the two promise wrappers returned by `cli.connect()` with `assert.deepEqual`. `connect()` is `async`, so each call wraps the shared `_connectPromise` in a fresh outer Promise — `deepEqual` was tolerating that prior to 24.15.0 but no longer does. The contract is "both calls resolve to the same result", so the test now awaits both and compares the resolved values (which are the same `result` object reference) with `assert.strictEqual`.

## CI matrix

`.github/workflows/test.yaml` bumps nodeVer test matrix "current" to 26 and adds LTS-releases since lowest supported release.
